### PR TITLE
Adding ignore_errors: yes for firewalld

### DIFF
--- a/tasks/docker/family/redhat.yml
+++ b/tasks/docker/family/redhat.yml
@@ -2,3 +2,4 @@
 # Disable and stop firewalld as it will break the SE
 - name: Avi SE | Prepare | Disable and stop Firewalld
   service: name="firewalld" state="stopped" enabled="no"
+  ignore_errors: yes


### PR DESCRIPTION
Not necessary firewalld installed, so in case of firewalld missing it should not prevent role to work